### PR TITLE
strip style attributes using dompurify

### DIFF
--- a/src/components/shared/DisruptionInfo/DisruptionInfo.js
+++ b/src/components/shared/DisruptionInfo/DisruptionInfo.js
@@ -46,7 +46,8 @@ const DisruptionInfo = ({ disruption }) => {
         <div
           className="wmnds-m-b-lg wmnds-col-1"
           dangerouslySetInnerHTML={{
-            __html: sanitize(disruption.description),
+            // Remove 'style' attributes from any descriptions
+            __html: sanitize(disruption.description, { FORBID_ATTR: ['style'] }),
           }}
         />
       ) : (


### PR DESCRIPTION
Strip `style=""` from disruption descriptions. [More info on what can be stripped out](https://github.com/cure53/DOMPurify#can-i-configure-dompurify).

Fixes #381 