### PR TITLE
Mobile fixes

### DIFF
--- a/src/components/ViewToShow/MapView/Map/Map.js
+++ b/src/components/ViewToShow/MapView/Map/Map.js
@@ -1,6 +1,7 @@
 // Using https://developers.arcgis.com/labs/browse/?product=javascript&topic=any and ESRI JS API
 import React, { useRef } from 'react';
 // Import custom hooks for map functionality
+import useWindowHeightWidth from 'customHooks/useWindowHeightWidth';
 import useCreateMap from './customHooks/useCreateMap';
 import useMapIconLayer from './customHooks/useMapIconLayer';
 import useMapPolyline from './customHooks/useMapPolyline';
@@ -11,7 +12,7 @@ import useMapGoto from './customHooks/useMapGoto';
 
 const WebMapView = () => {
   const mapRef = useRef(); // This ref is used to reference the dom node the map mounts on
-
+  const { appHeight } = useWindowHeightWidth();
   // Custom hook to define the core mapping settings/placeholders on page/component load
   const { mapState, viewState, currentLocationState } = useCreateMap(mapRef);
   // Custom hook to add the disruption icons to the map
@@ -29,6 +30,8 @@ const WebMapView = () => {
       className="webmap disruptions-esri-map"
       ref={mapRef}
       title="Disruptions map"
+      // Map needs to have a min height (so tray can slide over top) else when squashed, it sets zoom to 1
+      style={{ minHeight: appHeight && appHeight / 2 }}
     />
   );
 };

--- a/src/components/ViewToShow/MapView/Map/Map.scss
+++ b/src/components/ViewToShow/MapView/Map/Map.scss
@@ -7,12 +7,14 @@ $offset-top: $size-lg;
   height: 100%;
   width: 100%;
   background-color: #eee;
-  top: $offset-top;
+  position: absolute;
+  top: 0;
   left: 0;
-  z-index: -1;
+  z-index: 1;
   transition: height 0.35s ease;
 
   @media all and(min-width: 768px) {
+    position: static;
     width: calc(100% - 414px); // 414px is the width of the tray
     float: right;
   }

--- a/src/components/shared/Tray/MobileTray.js
+++ b/src/components/shared/Tray/MobileTray.js
@@ -4,6 +4,7 @@ import Swipe from 'react-easy-swipe';
 // Import Components
 import TrayComponents from './TrayComponents/TrayComponents';
 // Import styles
+import './MobileTray.scss';
 import s from './Tray.module.scss';
 import useMobileTrayMethods from './useMobileTrayMethods';
 
@@ -17,7 +18,7 @@ const MobileTray = () => {
     onSwipeUp,
     trayPosition,
     appHeight,
-  } = useMobileTrayMethods(slideableTray); // Pull in methods etc. to use for mobile swiper
+  } = useMobileTrayMethods(); // Pull in methods etc. to use for mobile swiper
 
   return (
     <div

--- a/src/components/shared/Tray/MobileTray.js
+++ b/src/components/shared/Tray/MobileTray.js
@@ -18,7 +18,7 @@ const MobileTray = () => {
     onSwipeUp,
     trayPosition,
     appHeight,
-  } = useMobileTrayMethods(); // Pull in methods etc. to use for mobile swiper
+  } = useMobileTrayMethods(slideableTray); // Pull in methods etc. to use for mobile swiper
 
   return (
     <div

--- a/src/components/shared/Tray/MobileTray.scss
+++ b/src/components/shared/Tray/MobileTray.scss
@@ -1,0 +1,16 @@
+// Fix for iOS pull-to-refresh when using tray
+@media all and (max-width: 767px) {
+  .mobile-tray-visible {
+    &,
+    body {
+      position: fixed;
+      overflow: hidden;
+      width: 100%;
+  
+      .disruptionsContainer {
+        overflow-y: scroll;
+        -webkit-overflow-scrolling: touch; /* enables “momentum” (smooth) scrolling */
+      }
+    }
+  }
+}

--- a/src/components/shared/Tray/Tray.module.scss
+++ b/src/components/shared/Tray/Tray.module.scss
@@ -58,8 +58,9 @@
   &:before {
     content: '';
     display: block;
-    height: 1px;
+    height: 3px;
     width: 90px;
+    border-radius: 1.5px; // must be half of the height
     margin: auto;
     position: absolute;
     top: 0;

--- a/src/components/shared/Tray/Tray.module.scss
+++ b/src/components/shared/Tray/Tray.module.scss
@@ -45,7 +45,7 @@
   height: 100%;
   width: 100%;
   position: relative;
-  transition: top 0.35s ease;
+  transition: top 0.35s ease; // add slight delay to account for minor state change delay
 
   &.trayIsOpen {
     overflow: auto;

--- a/src/components/shared/Tray/Tray.module.scss
+++ b/src/components/shared/Tray/Tray.module.scss
@@ -11,6 +11,7 @@
   position: absolute;
   height: 100%;
   transition: top 0.35s ease;
+  overflow: hidden;
 
   // On desktop/bigger displays
   @media only screen and (min-width: 768px) {
@@ -43,7 +44,8 @@
   display: block;
   height: 100%;
   width: 100%;
-  overflow: hidden;
+  position: relative;
+  transition: top 0.35s ease;
 
   &.trayIsOpen {
     overflow: auto;

--- a/src/components/shared/Tray/useMobileTrayMethods.js
+++ b/src/components/shared/Tray/useMobileTrayMethods.js
@@ -82,7 +82,7 @@ const useMobileTrayMethods = (slideableTray) => {
       innerTray
     ) {
       setTrayPosition(half || initialTrayPosition); // set tray to open
-      scrollToServiceInfo(); // scroll down to the relevatnt info in the tray
+      scrollToServiceInfo(); // scroll down to the relevant info in the tray
     }
 
     return () => {

--- a/src/components/shared/Tray/useMobileTrayMethods.js
+++ b/src/components/shared/Tray/useMobileTrayMethods.js
@@ -1,22 +1,29 @@
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useRef } from 'react';
+
 // Import contexts
+
 import { AutoCompleteContext, FetchDisruptionsContext, ModeContext } from 'globalState';
+
 // Import customHooks
+
 import useWindowHeightWidth from 'customHooks/useWindowHeightWidth';
 
-const useMobileTrayMethods = (slideableTray) => {
+const useMobileTrayMethods = () => {
   const [autoCompleteState] = useContext(AutoCompleteContext); // Get the state of modeButtons from modeContext
   const [fetchDisruptionsState] = useContext(FetchDisruptionsContext); // Get the state of modeButtons from modeContext
   const [modeState] = useContext(ModeContext); // Get the state of modeButtons from modeContext
-
   const { appHeight } = useWindowHeightWidth(); // Get window height and width
+
   const initialTrayPosition = 100; // Initial position of tray
   const half = appHeight / 2; // Get half of the container height for tray to swipe to
   const [trayPosition, setTrayPosition] = useState(initialTrayPosition); // Set initial position of tray
+  const { documentElement, body } = document;
+  const scrollTopRef = useRef(false); // ref to hold whether the tray is at the top of the page
 
   // Open tray if there is a selectedItem (map icon has been clicked) or a selected service
   useEffect(() => {
     const { selectedItem, selectedItemTo } = autoCompleteState;
+
     if (
       ((modeState.mode === 'train' && selectedItem.id && selectedItemTo.id) ||
         (modeState.mode !== 'train' && selectedItem.id)) &&
@@ -27,6 +34,7 @@ const useMobileTrayMethods = (slideableTray) => {
   }, [fetchDisruptionsState.data.length, half, autoCompleteState, modeState.mode]);
 
   // Changes map height based on the tray height
+
   useEffect(() => {
     const mapStyle = document.getElementById('disruptions-map').style;
 
@@ -37,11 +45,20 @@ const useMobileTrayMethods = (slideableTray) => {
     };
   }, [appHeight, trayPosition]);
 
+  // Apply a class to prevent elastic overscroll on iOS devices
+  useEffect(() => {
+    documentElement.classList.add('mobile-tray-visible');
+
+    return () => {
+      documentElement.classList.remove('mobile-tray-visible');
+    };
+  });
+
   // SWIPE METHODS USED TO CONTROL SCROLLING OF TRAY
-  const { documentElement, body } = document;
-  const onSwipeStart = () => {
+  const onSwipeStart = (e) => {
     body.style.overflow = 'hidden'; // Set body overflow to hidden, so we don't snap to body scrollbar
     documentElement.style.overscrollBehaviorY = 'none'; // Stops pull down to refresh in chrome on android
+    scrollTopRef.current = e.currentTarget.scrollTop === 0; // e.currentTarget (instead of e.target) makes sure that it's the Swiper component we're targeting
   };
 
   const onSwipeEnd = () => {
@@ -51,9 +68,7 @@ const useMobileTrayMethods = (slideableTray) => {
   };
 
   const onSwipeDown = () => {
-    const { scrollTop } = slideableTray.current.swiper; // Get DOM element, so we can check the scollTop
-
-    if (trayPosition === appHeight && scrollTop === 0) setTrayPosition(half); // If tray is open(position===appHeight) and the scrollTop is 0 (we're at the top of the tray scroll), then swipe down to half position
+    if (trayPosition === appHeight && scrollTopRef.current) setTrayPosition(half); // If tray is open(position===appHeight) and the scrollTop is 0 (we're at the top of the tray scroll), then swipe down to half position
     if (trayPosition === half) setTrayPosition(initialTrayPosition); // If tray is currently half then swipe down to default position
   };
 


### PR DESCRIPTION
This PR addresses multiple issues, namely the mobile tray's appearance and behaviour when the user selects a disruption.

- fixes #439 
- fixes #414 
- fixes #415 
- fixes #413 
- fixes #412 
- fixes #451 

