### PR TITLE
fix: filtering bug

### DIFF
--- a/src/components/ViewToShow/MapView/Map/customHooks/useFilterIcons.js
+++ b/src/components/ViewToShow/MapView/Map/customHooks/useFilterIcons.js
@@ -34,7 +34,11 @@ const useFilterIcons = (view, isIconLayerCreated) => {
     try {
       disruptionsFeatureLayerView = await view.whenLayerView(disruptionsFeatureLayer);
     } catch (error) {
-      console.log(error);
+      const { name } = error;
+      // MapView is destroyed on onUnmount which throws 'cancelled:layerview-create' when creating a layer view, so only log other errors
+      if (name !== 'cancelled:layerview-create') {
+        console.log(error);
+      }
     }
 
     let FeatureFilter;
@@ -107,6 +111,8 @@ const useFilterIcons = (view, isIconLayerCreated) => {
       point = new Point({ y: lat, x: lon });
     }
 
+    // Check if map is still mounted before filtering
+    if (!disruptionsFeatureLayerView) return;
     disruptionsFeatureLayerView.filter = new FeatureFilter({
       where: whereClause,
       distance,

--- a/src/components/ViewToShow/MapView/Map/customHooks/useHoverIcon.js
+++ b/src/components/ViewToShow/MapView/Map/customHooks/useHoverIcon.js
@@ -29,7 +29,11 @@ const useHoverIcon = (view, isIconLayerCreated) => {
       try {
         queryResult = await disruptionsFeatureLayer.queryFeatures(query);
       } catch (error) {
-        console.log(error);
+        const { name } = error;
+        // MapView is destroyed on onUnmount which throws 'load:instance-destroyed', so only log other errors
+        if (name !== 'load:instance-destroyed') {
+          console.log(error);
+        }
       }
 
       if (!queryResult?.features.length) return [];


### PR DESCRIPTION
Fix bug where app would crash if view was changed before map had fully mounted/loaded.

**To check fix:**
- Change to map view
- Change back to list view before map is visible (i.e when map side of the screen is grey)