### PR TITLE
fix: selected item now showing in list view

### DIFF
--- a/src/components/ViewToShow/ListView/DisruptionList/DisruptionList.js
+++ b/src/components/ViewToShow/ListView/DisruptionList/DisruptionList.js
@@ -21,7 +21,7 @@ const DisruptionList = () => {
     setDisruptionsShowing(increment);
   }, [disruptionsTotal]);
 
-  return disruptionsTotal > 1 ? (
+  return disruptionsTotal >= 1 ? (
     <>
       {filteredData.slice(0, disruptionsShowing).map((disruption) => (
         <DisruptionItem disruption={disruption} key={disruption.id} />


### PR DESCRIPTION
Fix `selectedItem` (or a `disruptionList.length = 1`) showing a good service message instead of the single disruption