### PR TITLE
fix: update 'show remaining disruptions' behaviour for roads

### DIFF
--- a/src/components/shared/Tray/TrayComponents/SelectedService/GoodServiceMessage/GoodServiceMessage.js
+++ b/src/components/shared/Tray/TrayComponents/SelectedService/GoodServiceMessage/GoodServiceMessage.js
@@ -89,10 +89,17 @@ const GoodServiceMessage = ({ isListView = false }) => {
     return `Good service ${timeText()} ${modeText()}.`;
   })();
 
-  const clearDisruptions = () => autoCompleteDispatch({ type: 'RESET_SELECTED_SERVICES' });
+  const clearSelectedServices = () => {
+    if (modeState.mode === 'roads') {
+      autoCompleteDispatch({ type: 'RESET_SELECTED_ITEM', payload: { to: false } });
+      return;
+    }
+    autoCompleteDispatch({ type: 'RESET_SELECTED_SERVICES' });
+  };
+
   const showOtherDisruptions =
     isListView && autoCompleteState.selectedItem.selectedByMap ? (
-      <button className="wmnds-btn wmnds-btn--link" type="button" onClick={clearDisruptions}>
+      <button className="wmnds-btn wmnds-btn--link" type="button" onClick={clearSelectedServices}>
         Show remaining disruptions.
       </button>
     ) : (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43111519/124588133-60570e00-de50-11eb-9429-5d4a520a516a.png)

When coming from a road disruption email, if the user uses list view, they see this screen if the disruption has cleared.

**Previously**
When the user clicked 'show remaining disruptions', it would fully clear the search (same as clicking 'Clear search'). This meant that the user had to re-enter their address if they wanted to see road disruptions for their selected area.

**After change**
Clicking 'show remaining disruptions' only clears the selected item (the cleared disruption) and then shows the user the remaining disruptions within their selected area. They can still fully clear the search in the same way.