### PR TITLE
fix: 'Good service' message on map view

### DIFF
--- a/src/components/shared/Tray/TrayComponents/SelectedService/customHooks/useShowSelectedServiceInfo.js
+++ b/src/components/shared/Tray/TrayComponents/SelectedService/customHooks/useShowSelectedServiceInfo.js
@@ -15,6 +15,7 @@ const useShowSelectedServiceInfo = () => {
   // Create boolean variables to use in comparisons
   const isModeSelected = Object.keys(modeState).length !== 0 && modeState.mode !== null;
   const anyDisruptionsToShow = disruptedServices.length > 0;
+  const isSelectedItemSelectedByMap = selectedItem.id && selectedItem.selectedByMap;
   // Below creates an object that shows the state of the autoComplete inputs per mode.
   const areSelectedItems = (() => {
     const defaultState = {
@@ -73,12 +74,13 @@ const useShowSelectedServiceInfo = () => {
     !anyDisruptionsToShow &&
     (!isModeSelected ||
       areSelectedItems.allEmpty ||
+      isSelectedItemSelectedByMap ||
       (areSelectedItems.allSelected && areSelectedItems.doneWithSideEffects));
 
   const showDisruptedServices =
     isMapVisible &&
     anyDisruptionsToShow &&
-    ((areSelectedItems.allSelected && !isRoadsMode) || selectedItem.selectedByMap);
+    ((areSelectedItems.allSelected && !isRoadsMode) || isSelectedItemSelectedByMap);
 
   const showLineBreak = showInfoAboutSelectedService && showServiceMessage && !isRoadsMode;
 

--- a/src/customHooks/useFilterLogic.js
+++ b/src/customHooks/useFilterLogic.js
@@ -55,7 +55,7 @@ const useFilterLogic = () => {
     }
 
     // SelectedMapDisruption filtering
-    if (autoCompleteState.selectedItem.selectedByMap) {
+    if (autoCompleteState.selectedItem.selectedByMap && autoCompleteState.selectedItem.id) {
       filteredData = filteredData.filter(
         (disrItem) => disrItem.id === autoCompleteState.selectedItem.id
       );


### PR DESCRIPTION
Fix a bug where the 'This disruption has cleared' message was not appearing on map view for train disruptions. 

**Cause**
Now that the default mode is `bus`, we need to specify a mode via url parameters when linking from a disruption email. 

e.g. `{{ disruptionsUrl }}?selectedByMap=true&selectedItem=1054061806&mode=train`

When doing so, the 'This disruption has cleared' message wasn't showing properly on map view for trains.

**After change**
The 'This disruption has cleared' message shows in the sidebar on map view 