### PR TITLE
merge master into develop - wont let me do it manually

### DIFF
--- a/src/components/ViewToShow/ListView/DisruptionList/DisruptionList.js
+++ b/src/components/ViewToShow/ListView/DisruptionList/DisruptionList.js
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 // Import contexts
 import useFilterLogic from 'customHooks/useFilterLogic';
-import GoodServiceMessage from 'components/shared/Tray/TrayComponents/SelectedService/GoodServiceMessage/GoodServiceMessage';
+import NoKnownDisruptionMessage from 'components/shared/Tray/TrayComponents/SelectedService/NoKnownDisruptionMessage/NoKnownDisruptionMessage';
 import DisruptionItem from './DisruptionItem/DisruptionItem';
 
 const DisruptionList = () => {
@@ -37,7 +37,7 @@ const DisruptionList = () => {
       )}
     </>
   ) : (
-    <GoodServiceMessage isListView />
+    <NoKnownDisruptionMessage isListView />
   );
 };
 

--- a/src/components/shared/Tray/TrayComponents/SelectedService/NoKnownDisruptionMessage/NoKnownDisruptionMessage.js
+++ b/src/components/shared/Tray/TrayComponents/SelectedService/NoKnownDisruptionMessage/NoKnownDisruptionMessage.js
@@ -1,0 +1,132 @@
+/* eslint-disable react/prop-types */
+import React, { useContext } from 'react';
+// State
+import { ModeContext, WhenContext, AutoCompleteContext } from 'globalState';
+import { getSearchParam } from 'globalState/helpers/URLSearchParams';
+// Components
+import Icon from 'components/shared/Icon/Icon';
+
+const NoKnownDisruptionMessage = ({ isListView = false }) => {
+  const [modeState] = useContext(ModeContext);
+  const [whenState] = useContext(WhenContext);
+  const [autoCompleteState, autoCompleteDispatch] = useContext(AutoCompleteContext);
+
+  const { selectedItem, selectedItemTo, selectedLocation } = autoCompleteState;
+
+  const timeText = () => {
+    const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+
+    switch (whenState.when) {
+      case 'tomorrow':
+        return 'expected tomorrow';
+
+      case 'customDate':
+        return `expected on ${new Date(whenState.whenCustomDate).toLocaleDateString(
+          'en-GB',
+          dateOptions
+        )}`;
+
+      default:
+        return 'today';
+    }
+  };
+
+  const modeText = () => {
+    switch (modeState.mode) {
+      case 'bus':
+        return selectedItem.serviceNumber
+          ? `on the ${selectedItem.serviceNumber.toUpperCase()} service`
+          : 'on all bus routes';
+
+      case 'train':
+        return selectedItem.id && selectedItemTo.id
+          ? `between ${selectedItem.stopName} and ${selectedItemTo.stopName}`
+          : 'on all train lines';
+
+      case 'tram':
+        return 'across all tram stops';
+
+      case 'roads':
+        return selectedLocation.address
+          ? `within ${selectedLocation.radius} mile${selectedLocation.radius > 1 ? 's' : ''} of ${
+              selectedLocation.address
+            }`
+          : 'on all roads';
+
+      default:
+        return 'across all modes of travel';
+    }
+  };
+
+  const hasCachedDisruption = () => {
+    const autoCompletesAreEmpty = !selectedItem.id && !selectedItemTo.id;
+    if (selectedItem.selectedByMap || autoCompletesAreEmpty) {
+      return false;
+    }
+
+    switch (modeState.mode) {
+      case 'bus':
+        return selectedItem.severity !== undefined && selectedItem.severity !== 'none';
+
+      default:
+        return selectedItem.severity !== 'none' || selectedItemTo.severity !== 'none';
+    }
+  };
+
+  const message = (() => {
+    if (getSearchParam('selectedByMap') && getSearchParam('selectedItem')) {
+      // Update the message for a user coming from an email link
+      // if the code reaches here it means there is good service and that disruption no longer exists i.e. has been cleared
+      return 'This disruption has cleared.';
+    }
+
+    if (hasCachedDisruption()) {
+      // If a disuruption is cached then a selectedItem will have disruption info from the AutoCompleteAPI
+      // however the disruption won't exist on the DisruptionsAPI so it will have been cleared recently.
+      return `A disruption has recently cleared ${modeText()}.`;
+    }
+
+    return `No known disruptions ${timeText()} ${modeText()}.`;
+  })();
+
+  const clearSelectedServices = () => {
+    if (modeState.mode === 'roads') {
+      autoCompleteDispatch({ type: 'RESET_SELECTED_ITEM', payload: { to: false } });
+      return;
+    }
+    autoCompleteDispatch({ type: 'RESET_SELECTED_SERVICES' });
+  };
+
+  const showOtherDisruptions =
+    isListView && autoCompleteState.selectedItem.selectedByMap ? (
+      <button className="wmnds-btn wmnds-btn--link" type="button" onClick={clearSelectedServices}>
+        Show remaining disruptions.
+      </button>
+    ) : (
+      ''
+    );
+
+  return (
+    <div className={`wmnds-msg-summary wmnds-col-1 ${isListView ? '' : 'wmnds-m-t-lg'}`}>
+      <div className="wmnds-msg-summary__header">
+        <Icon iconName="general-success" iconClass="wmnds-msg-summary__icon" />
+        <h3 className="wmnds-msg-summary__title">No known disruptions</h3>
+        <div className="wmnds-msg-summary__info">
+          <p className="wmnds-m-b-none">
+            {message}
+            {showOtherDisruptions}
+          </p>
+          {whenState.when !== 'now' && (
+            <p className="wmnds-m-t-sm wmnds-m-b-none">
+              Service is subject to change, so please check before you travel.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NoKnownDisruptionMessage;
+
+// E.g good service today on all train lines or good service between [selected dates] as of today, but it is subject to change, check before you travel.

--- a/src/components/shared/Tray/TrayComponents/SelectedService/SelectedService.js
+++ b/src/components/shared/Tray/TrayComponents/SelectedService/SelectedService.js
@@ -5,7 +5,7 @@ import useShowSelectedServicesInfo from './customHooks/useShowSelectedServiceInf
 import DisruptedService from './DisruptedService/DisruptedService';
 import InfoAboutSelectedService from './InfoAboutSelectedService/InfoAboutSelectedService';
 import SaveRoutesMessage from './SaveRoutesMessage/SaveRoutesMessage';
-import GoodServiceMessage from './GoodServiceMessage/GoodServiceMessage';
+import NoKnownDisruptionMessage from './NoKnownDisruptionMessage/NoKnownDisruptionMessage';
 
 const SelectedService = () => {
   const {
@@ -27,7 +27,7 @@ const SelectedService = () => {
         </>
       )}
       {/* If no selectedData then it must be good service */}
-      {showServiceMessage && <GoodServiceMessage />}
+      {showServiceMessage && <NoKnownDisruptionMessage />}
       {/* If there are selectedData then there must be disruptions, loop through */}
       {showDisruptedServices &&
         disruptedServices.map((disruption) => (


### PR DESCRIPTION
* Feature/203 links and branding (#642)

* website title and replan journey URL updated

* updated description and short name

* added new header and footer link to index page

* amend header and update social media link on share-button

* update feedback link and key

* updated feedback link id

* updated feedback link id

* reinstall package-lock

* remove feedback link and reinstall package-lock

* reinstall package-lock

* remove unused vars

Co-authored-by: Sudheer Kotha <SudheerKotha@wmca.org.uk>
Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Bug/203 links filter and video (#645)

* moved feedback link to env variable and updated the header

* add keys to netlify and remove unused vars on header

Co-authored-by: Sudheer Kotha <SudheerKotha@wmca.org.uk>
Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Feature/203 links and branding (#649)

* website title and replan journey URL updated

* updated description and short name

* added new header and footer link to index page

* amend header and update social media link on share-button

* update feedback link and key

* updated feedback link id

* updated feedback link id

* reinstall package-lock

* remove feedback link and reinstall package-lock

* reinstall package-lock

* remove unused vars

* updating twitter and email links

Co-authored-by: Sudheer Kotha <SudheerKotha@wmca.org.uk>
Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Feature/204 upgrade disruptions UI in line with tfwm (#650)

* align the filter options and change the button styling for map and list

* replacing locate map icon and updating zoom map icons

* alignment of filter options and map button styling

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* ncu updates applied to project (#653)

* npm-check-updates applied to project

* updated comments

* clear npm cache and replace propTypes any with propTypes object

* fix es-lint error to move disruptionsData in its own useMemo() hook

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Feature/upgrade node and other dependencies (#656)

* ncu updates applied to project

* updated comments

* clear npm cache and replacing propTypes any with propTypes object

* fix eslint error to move disruptionsData in its own useMemo() hook

* applied npm upgrade and show header title smaller for mobiles

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Feature/upgrade node and other dependencies (#657)

* ncu updates applied to project

* updated comments

* clear npm cache and replacing propTypes any with propTypes object

* fix eslint error to move disruptionsData in its own useMemo() hook

* applied npm upgrade and show header title smaller for mobiles

* update node module and adjusted title margin

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Feature/adjust header and footer (#658)

* adjusted header for mobile screen

* adjusted header margin

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* npm install changes updated after mergt

* added new message type NoKnownDisruptionMessage replacing 'good service' (#670)

* added new message type NoKnownDisruptionMessage replacing 'good service'

* remove strike message

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

* Bug/change good service to unknown disruption (#671)

* added new message type NoKnownDisruptionMessage replacing 'good service'

* remove strike message

* replacing GoodServiceMessage with NoKnownDisruptionMessage

Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>

Co-authored-by: Sudheer Kotha <SudheerKotha@wmca.org.uk>
Co-authored-by: Sudheer Kotha <sudheer.kotha@wmca@org.uk>